### PR TITLE
Update index.html to correct typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@ hide_banner: true
                   <p class="catalog-item__text">
                     <a href="https://stargate.io/docs/stargate/1.0/developers-guide/api_ref/openapi_rest_ref.html"
                       target="_blank" rel="noopener noreferrer">
-                      Save and search schemaless JSON documentsed
+                      Save and search schemaless JSON documents
                     </a>
                   </p>
                 </div>


### PR DESCRIPTION
Corrects a typo in index.html "Save and search schemaless JSON documentsed" to "Save and search schemaless JSON documents"