### PR TITLE
DKG: blog typo in examples

### DIFF
--- a/_posts/2020-12-09-announcing-stargate-10-ga-rest-graphql-schemaless-json-for-your-cassandra-development.md
+++ b/_posts/2020-12-09-announcing-stargate-10-ga-rest-graphql-schemaless-json-for-your-cassandra-development.md
@@ -187,7 +187,7 @@ const user = await usersCollection.get(user.documentId);
 And, lastly, if you need to delete that user:
 
 {% highlight javascript %}
-// delete the post
+// delete the user
 const user = await usersCollection.delete(user.documentId);
 {% endhighlight %}
 


### PR DESCRIPTION
fixing a typo in a comment from an example.

"delete the post" needs to be "delete the user"