### PR TITLE
fixing CI build to avoid building on PRs

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # skip if build is triggered by pull request
-if [ $TRAVIS_PULL_REQUEST == "true" ]; then
+if [ $TRAVIS_PULL_REQUEST != "false" ]; then
   echo "this is PR, exiting"
   exit 0
 fi


### PR DESCRIPTION
Fixed logic error in build script that is meant to cause exit if build is triggered by a PR

According to [TravisCI docs](https://docs.travis-ci.com/user/environment-variables/#default-environment-variables), the value of the environment variable `TRAVIS_PULL_REQUEST` is the PR number, not `true`:

> TRAVIS_PULL_REQUEST: The pull request number if the current job is a pull request, “false” if it’s not a pull request.

Need to check that the value is not `false`
