### PR TITLE
fixing link on GitHub Discussions button

### DIFF
--- a/community.html
+++ b/community.html
@@ -42,7 +42,7 @@ has_marketo: true
             </span>
             <span>Github</span>
           </a>
-          <a href="https://github.com/{{ site.github_username }}/discussions" target="_blank" rel="noopener noreferrer"
+          <a href="https://github.com/{{ site.github_username }}/stargate/discussions" target="_blank" rel="noopener noreferrer"
             class="btn btn-icon btn-github">
             <span>
               <svg width="30" height="30" viewBox="0 0 30 30" fill="none" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
On the [community page](https://stargate.io/community), the GitHub Discussions button links to 

`https://github.com/stargate/discussions`

instead of 

`https://github.com/stargate/stargate/discussions`

![Screen Shot 2022-02-03 at 2 33 19 PM](https://user-images.githubusercontent.com/12115970/152432575-cae729ba-0f8b-4ab7-b995-e0e944093998.png)
