### PR TITLE
add CLA to community page

### DIFF
--- a/community.html
+++ b/community.html
@@ -112,7 +112,14 @@ has_marketo: true
               href="https://github.com/stargate/stargate" target="_blank" rel="noopener noreferrer">README</a> in the
             main stargate repository to get a grasp of the project layout and reference the
             <a href="https://github.com/stargate/stargate/blob/master/CONTRIBUTING.md">CONTRIBUTING.md</a>
-            file for detailed steps. If you're interested in contributing but don't know where to start,
+            file for detailed steps. </p>
+
+            <p>Acceptance of the DataStax <a href="https://cla.datastax.com/" target="_blank"
+                                             rel="noopener noreferrer"> contributor license agreement</a>
+              (CLA) is required in order for us to be able to accept your code contribution.
+              You will see this on the standard pull request checklist for the Stargate repositories.</p>
+
+            <p> If you're interested in contributing but don't know where to start,
             we also recommend looking for a <a
             href="https://github.com/stargate/stargate/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">
             good first issue</a> in the main repository.</p>


### PR DESCRIPTION
Add reference to the Datastax contributor license agreement to the community page.
