### PR TITLE
Update discord link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,7 @@
             class="footer-social-link">
             {% include logos/discussions.html %}
           </a>
-          <a href="https://discord.com/invite/5gY8GDB" target="_blank" rel="noopener noreferrer"
+          <a href="https://discord.gg/HHtMAvjaZB" target="_blank" rel="noopener noreferrer"
             class="footer-social-link">
             {% include logos/discord.html %}
           </a>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -56,7 +56,7 @@
             class="nav-item nav-link nav-link-logo">
             {% include logos/discussions.html %}
           </a>
-          <a href="https://discord.com/invite/5gY8GDB" target="_blank" rel="noopener noreferrer"
+          <a href="https://discord.gg/HHtMAvjaZB" target="_blank" rel="noopener noreferrer"
             class="nav-item nav-link nav-link-logo">
             {% include logos/discord.html %}
           </a>

--- a/_posts/2022-01-06-reaching-the-first-milestone.md
+++ b/_posts/2022-01-06-reaching-the-first-milestone.md
@@ -52,6 +52,6 @@ Since one of the Stargate v2 goals is to be more Docker/Kubernetes friendly, we�
 
 Now that we’ve mostly completed breaking our first API service out of the monolith, we’re working on setting up performance testing, reviewing the architecture, and getting ready to factor the GraphQL and Document APIs into their own services. 
 
-We’d love to hear your inputs about the new architecture and the progress that is being made on the new implementation, so feel free to jump into the conversation on [Discord](https://discord.com/invite/5gY8GDB) with questions, or comment on our [design discussions on GitHub](https://github.com/stargate/stargate/discussions?discussions_q=label:stargate-v2).
+We’d love to hear your inputs about the new architecture and the progress that is being made on the new implementation, so feel free to jump into the conversation on [Discord](https://discord.gg/HHtMAvjaZB) with questions, or comment on our [design discussions on GitHub](https://github.com/stargate/stargate/discussions?discussions_q=label:stargate-v2).
 
 _Special thanks to Tatu Saloranta, Olivier Michallat, Doug Wettlaufer and Mark Stone for their contributions to the Stargate v2 effort and this post._

--- a/_posts/2022-09-12-stargate-v2-beta.md
+++ b/_posts/2022-09-12-stargate-v2-beta.md
@@ -8,6 +8,7 @@ author_info:
     first: "Mark"
     last: "Stone"
   picture: "assets/images/stargate-profile.png"
+extra_authors: [ "Jeff Carpenter"]
 ---
 
 Last Friday, we released the first [Beta](https://github.com/stargate/stargate/releases/tag/v2.0.0-BETA-1) for Stargate v2. In this post we’ll look at why this is a major milestone for the project and how you can try out this new release yourself.


### PR DESCRIPTION
Link to Discord server was reported as expired. Created a new Discord link which is supposed to never expire: https://discord.gg/HHtMAvjaZB. Updated this in the site navigation.

Also includes a commit to take advantage of the multiple authors feature to update the beta blog post.