### PR TITLE
Updated onetrust cookie law script

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -39,8 +39,12 @@
   <script
   src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js"
   type="text/javascript"
-  data-domain-script="2d329c5f-8feb-4a63-8c63-03232bcaacbd"
-    async=""></script>
+  charset="UTF-8"
+  data-domain-script="7aeda1d3-ab5d-4ac1-b17d-d1b37473af5a"
+  async=""></script>
+  <script type="text/javascript">
+    function OptanonWrapper() { }
+  </script>
 
   {% if page.has_marketo %}
     <script src="{{ '/assets/js/forms.js' | relative_url }}"></script>


### PR DESCRIPTION
## Summary
Updated OneTrust Cookie banner to use stargate settings instead of DS settings.