### PR TITLE
cleans up github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,26 +8,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/cache@v2
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
 
+    steps:
+      - uses: actions/checkout@v3
+
+      # install ruby
+      # action already handles gems caches
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.0
           bundler-cache: true
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v3
-      - name: Install dependencies
-        run: bundle install
+
+      # simple build only
       - name: Build jekyll site
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,29 +15,28 @@ concurrency:
 jobs:
   jekyll:
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/cache@v3
-        with:
-          path: vendor/bundle
-          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile') }}
-          restore-keys: |
-            ${{ runner.os }}-gems-
 
+    steps:
+      - uses: actions/checkout@v3
+
+      # install ruby
+      # action already handles gems caches
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.0
           bundler-cache: true
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v3
-      - name: Install dependencies
-        run: bundle install
+
+      # build with baseurl pointing to the pages base_path
       - name: Build jekyll site
         run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
         env:
           JEKYLL_ENV: production
+
+      # deploy
       - name: Deploy to GH Pages
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 
 1. You need to use ruby version >= 2.5.0
 2. Install all the dependencies: 
-   * `npm install` to install package.json dependencies 
-   * ```
-     bundle config --local path ./vendor/bundle
-   	 bundle install
-	 ```
-	 to install gemfile dependencies
+   ```bash
+   npm ci
+   bundle config --local path ./vendor/bundle
+   bundle install
+   ```
 3. Run the project with `npm start`. This will run the jekyll serve script and will open the development URL.
 
 ## How to build this project
 
 In order to build, you can run:
 
-```
+```bash
+npm ci
 npm run build
 npm run serve
 ```

--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 # Stargate.io Website
 
-### How to run this project
+## How to run this project
 
 1. You need to use ruby version >= 2.5.0
 2. Install all the dependencies: 
-				- `npm install` -> to install package.json dependencies 
-				- `bundle install` -> to install gemfile dependencies
+   * `npm install` to install package.json dependencies 
+   * ```
+     bundle config --local path ./vendor/bundle
+   	 bundle install
+	 ```
+	 to install gemfile dependencies
 3. Run the project with `npm start`. This will run the jekyll serve script and will open the development URL.
+
+## How to build this project
+
+In order to build, you can run:
+
+```
+npm run build
+npm run serve
+```
+
+This will build the production-like files and serve on http://localhost:8080.


### PR DESCRIPTION
As agreed with @jeffreyscarpenter I clean-up the actions, extended the readme. The actions are simplified as many steps where not needed.

The only remaining question I would have is why is there npm at all? It was not use until now in the actions. It's not sure now dependencies are used. There are absolutely no scripts that use those dependencies. I am quite confused if it's needed at all. Maybe ruby does something under the hood.