### PR TITLE
Removing "data API gateway" language

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@ hide_banner: true
   <section class="homepage__hero" id="hero">
     <div class="container">
       <div class="row">
-        <div class="col-md-10">
-          <h1 class="homepage__hero--title">Open Source Data API Gateway</h1>
+        <div class="col-md-12">
+          <h1 class="homepage__hero--title">API Gateway for Apache Cassandra</h1>
         </div>
       </div>
       <div class="row">
-        <div class="col-md-6 homepage__hero--subtitle">
+        <div class="col-md-8 homepage__hero--subtitle">
           <p>
-            Stargate is a data API gateway that deploys between your apps and
+            Stargate is an open source API gateway that deploys between your applications and
             your Apache Cassandra database(s).
           </p>
         </div>
@@ -40,13 +40,6 @@ hide_banner: true
             </svg>
             <span>Download Now</span>
           </a>
-          <a
-            href="https://astra.datastax.com"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="btn btn-purple"
-            >Try on Astra DB free</a
-          >
         </div>
       </div>
 


### PR DESCRIPTION
Stargate website uses "data API gateway" language which is super confusing as we also have the Data API now. Removed such references.

Also removed the "Try in Astra" button as we are deprecating these APIs there.